### PR TITLE
[metal] Bright terminal.ansiBrightBlack for displaying log in terminal

### DIFF
--- a/themes/metal-theme.json
+++ b/themes/metal-theme.json
@@ -56,7 +56,7 @@
         "gitDecoration.conflictingResourceForeground": "#ff92e4",
 
         "terminal.foreground": "#F9FAFF",
-        "terminal.ansiBrightBlack": "#212225",
+        "terminal.ansiBrightBlack": "#7e7e7e",
         "terminal.ansiBrightCyan": "#9ce7fd",
         "terminal.ansiBrightGreen": "#c0e9c6",
         "terminal.ansiBrightMagenta": "#ff92e4",


### PR DESCRIPTION
Dear Developer.

Actually I like `Metal(Shark)` theme and have no idea on VSCode theme.
Some logs are not displayed due to the same color with the background, so that I just make it a little bit brighter.

### Problem

Some logs in terminal is not displayed because it maybe the same color with background.
SQL parameter log is not displayed well.

```sql
query: SELECT `User`.`id` AS `User_id`, `User`.`username` AS `User_username`, `User`.`password` AS `User_password`, `User`.`email` AS `User_email`, `User`.`provider` AS `User_provider`, `User`.`provider_id` AS `User_provider_id`, `User`.`image_url` AS `User_image_url`, `User`.`created_at` AS `User_created_at`, `User`.`updated_at` AS `User_updated_at` FROM `user` `User` WHERE `User`.`id` IN (?) -- PARAMETERS: [1]
query: START TRANSACTION
query: UPDATE `user` SET `provider_id` = ?, `updated_at` = CURRENT_TIMESTAMP WHERE `id` IN (?) -- PARAMETERS: ["107855374156215311068",1]
query: SELECT `User`.`id` AS `User_id`, `User`.`updated_at` AS `User_updated_at` FROM `user` `User` WHERE `User`.`id` = ? -- PARAMETERS: [1]
```

### VSCode default theme

Logs are displayed well.

![Xnip2020-06-13_14-16-36](https://user-images.githubusercontent.com/365500/84560952-8613ff80-ad83-11ea-8130-28dd5f935bc3.jpg)

### Current Metal (Shark)

Logs are not displayed.

![Xnip2020-06-13_14-17-19](https://user-images.githubusercontent.com/365500/84560950-844a3c00-ad83-11ea-8e50-565ee6b8fad8.jpg)

### PR

Logs are displayed well.

![Xnip2020-06-13_14-27-25](https://user-images.githubusercontent.com/365500/84560948-7f858800-ad83-11ea-9607-69b928643424.jpg)

Thanks


